### PR TITLE
[Hotfix] Node.js 버전 설정 관련 CI 설정 파일 업데이트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
-          cache: "pnpm"
+          node-version: "22.6.0"
 
       - name: Install pnpm
         run: npm install -g pnpm
@@ -38,8 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
-          cache: "pnpm"
+          node-version: "22.6.0"
 
       - name: Install pnpm
         run: npm install -g pnpm
@@ -60,8 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
-          cache: "pnpm"
+          node-version: "22.6.0"
 
       - name: Install pnpm
         run: npm install -g pnpm


### PR DESCRIPTION
## 🚀 작업 내용

- Node.js 설정하는 과정에서 추가했던 cache: 'pnpm' 관련 문제 발생하여 삭제하고, Node.js 버전 일관성 유지를 위해 22.06 버전으로 고정하도록 수정

## 📝 참고 사항

- merge 된 후에 develop 브랜치 pull 받아서 최신 상태로 동기화 될 수 있도록 해주세요! Actions에서 오류가 안 난다면 다시 한 번 말씀드리겠습니다!!

## 🖼️ 스크린샷

![image](https://github.com/user-attachments/assets/ed6aaa57-52ce-4a4b-a114-af2bfa999bd9)

## 🚨 관련 이슈

- close #14 

## ✅ 체크리스트

- [x] Code Review 요청
- [x] Label 설정
- [x] PR 제목 규칙에 맞는지 확인
