### PR TITLE
[Fix] Button 컴포넌트 크기 조정

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -39,9 +39,9 @@ export default function Button({
   };
 
   const sizeStyles = {
-    small: 'w-[10.1rem] h-[4rem] px-[2rem] py-[0.8rem] text-[2rem] font-[300]',
-    default: 'w-[12.1rem] h-[5.6rem] px-[2.4rem] py-[1.6rem] text-[2.4rem] font-[300]',
-    large: 'w-[19.6rem] h-[5.6rem] px-[2rem] py-[1.6rem] text-[2.4rem] font-bold',
+    small: 'w-fit h-[4rem] px-[2rem] py-[0.8rem] text-[2rem] font-[300]',
+    default: 'w-fit h-[5.6rem] px-[2.4rem] py-[1.6rem] text-[2.4rem] font-[300]',
+    large: 'w-fit h-[5.6rem] px-[2rem] py-[1.6rem] text-[2.4rem] font-bold',
   };
 
   const interactionStyles = {


### PR DESCRIPTION
## 🚀 작업 내용

- 버튼 너비가 고정되어 있어 버튼 내부 텍스트 길이가 길 경우 버튼 텍스트가 잘려서 보이는 문제가 발생, 
   버튼 크기에서 width 고정하지 않고 자동으로 조정되도록 수정하였습니다.

## 📝 참고 사항

- N

## 🖼️ 스크린샷

<img width="144" alt="스크린샷 2024-08-21 오전 12 54 25" src="https://github.com/user-attachments/assets/8d4b4c57-538e-4fb5-abcc-42631cce7bca">


## 🚨 관련 이슈

- close #7 

## ✅ 체크리스트

- [x] Code Review 요청
- [x] Label 설정
- [x] PR 제목 규칙에 맞는지 확인
